### PR TITLE
fix application crushes with error in AsyncSearch().count() method

### DIFF
--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -427,7 +427,8 @@ class AsyncSearch(Request):
 
         d = self.to_dict(count=True)
         # TODO: failed shards detection
-        return await es.count(index=self._index, body=d, **self._params)["count"]
+        resp_count = await es.count(index=self._index, body=d, **self._params)
+        return resp_count["count"]
 
     async def execute(self, ignore_cache=False):
         """

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -427,7 +427,8 @@ class Search(Request):
 
         d = self.to_dict(count=True)
         # TODO: failed shards detection
-        return es.count(index=self._index, body=d, **self._params)["count"]
+        resp_count = es.count(index=self._index, body=d, **self._params)
+        return resp_count["count"]
 
     def execute(self, ignore_cache=False):
         """

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -282,8 +282,8 @@ class Date(Field):
         if isinstance(data, date):
             return data
         if isinstance(data, integer_types):
-            # Divide by a float to preserve milliseconds on the datetime.
-            return datetime.utcfromtimestamp(data / 1000.0)
+            # Not needed divide by a float to preserve milliseconds on the datetime, because 'data' already in the required format.
+            return datetime.utcfromtimestamp(data)
 
         raise ValidationException("Could not parse date from the value (%r)" % data)
 


### PR DESCRIPTION
I tried using AsyncSearh with next code:
```python
from elasticsearch_dsl import AsyncSearch

search = AsyncSearch(using='my_connection_name', index='my_index_name')
search = search.filter('term', docType='my_docType_name')
result = search.count()
```
and I get the following error:
```python
  <...>
  File "<..>/elasticsearch_dsl/_async/search.py", line 430, in count
    return await es.count(index=self._index, body=d, **self._params)["count"]
TypeError: 'coroutine' object is not subscriptable
```


before this bug fix, when calling AsyncSearch().count(), the application crashes with the error `TypeError: 'coroutine' object is not subscriptable`